### PR TITLE
Only inter-group bonds in main bondAtomList field

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -867,7 +867,7 @@ The `sequence` string contains the full construct, not just the resolved residue
 
 *Type*: [Binary](#types) data that decodes into an array of 32-bit signed integers.
 
-*Description*: Pairs of values represent indices of covalently bonded atoms. The indices point to the [Atom data](#atom-data) arrays. Only covalent bonds may be given.
+*Description*: Pairs of values represent indices of covalently bonded atoms. The indices point to the [Atom data](#atom-data) arrays. Only covalent bonds may be given. Only inter-groups bonds are expected here: intra-groups bonds are defined later in the [groupList](#groupList) section.
 *Note*: This is an optional field in that if your mmtf file contains no bonds, the field is not required to exist (for decoding purposes).  If bonds exist this must be defined.
 
 *Example*:


### PR DESCRIPTION
The specification does not state that only the inter group bonds are expected in the main bondAtomList field, except implicitly in the pseudo-code for decoding. If one writes an encoder that writes all bonds in the main bondAtomList, the output mmtf file would break many parsers implementations and the file would have poor compression ratios.